### PR TITLE
Fix build errors in SalesOrderEditScreen

### DIFF
--- a/lib/modules/orders/views/sales_order_edit_screen.dart
+++ b/lib/modules/orders/views/sales_order_edit_screen.dart
@@ -304,7 +304,9 @@ class _SalesOrderEditScreenState extends State<SalesOrderEditScreen> {
                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("All items in stock!")));
               }
             }
-          ), // Add comma here ,
+          ), // ElevatedButton for "Check Stock Availability" ends here
+          // Comma added to separate from the Consumer widget below
+          ,
         Consumer<OrderController>(builder: (ctx, ctrl, _) {
             if(ctrl.selectedSalesOrder?.id != widget.salesOrder?.id || ctrl.itemShortages.isEmpty) return SizedBox.shrink();
             return Padding(padding: EdgeInsets.symmetric(vertical:8), child: Column(


### PR DESCRIPTION
This commit attempts to fix build errors previously reported in lib/modules/orders/views/sales_order_edit_screen.dart. The main change involved normalizing comma placement within a Column widget in the _buildStatusAndCompletionSection method to prevent parsing issues.

This commit builds upon previous attempts to fix analyzer issues and test file syntax.

Verification Caveat:
Crucially, I could not execute 'flutter analyze' and 'flutter test' due to a persistent inability to locate the Flutter SDK in the execution environment. Therefore, while the implemented changes are intended to resolve the reported build errors, this could not be directly verified. Manual verification of analysis, build, and tests is strongly recommended.